### PR TITLE
Support cache key fn for dataloaders

### DIFF
--- a/graphql_sync_dataloaders/sync_dataloader.py
+++ b/graphql_sync_dataloaders/sync_dataloader.py
@@ -1,5 +1,5 @@
 import contextvars
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
 from graphql.pyutils import is_collection
 
@@ -42,12 +42,15 @@ class DataloaderBatchCallbacks:
 
 
 class SyncDataLoader:
-    def __init__(self, batch_load_fn):
+    def __init__(self, batch_load_fn, cache_key_fn: Callable[[Any], str] | None = None):
         self._batch_load_fn = batch_load_fn
+        self._cache_key_fn = cache_key_fn
         self._cache = {}
         self._queue = []
 
     def load(self, key):
+        if self._cache_key_fn:
+            key = self._cache_key_fn(key)
         try:
             return self._cache[key]
         except KeyError:


### PR DESCRIPTION
## Description

Adds support for a custom cache key function when initializing dataloaders. This allows for usage of the dataloader cache when passing through more complex objects/classes

## Testing

Existing + new unit tests pass:

```bash
(venv) jamie@Jamies-MacBook-Pro ~/Documents/code/gql-sync-dataloaders/graphql-sync-dataloaders (jamie/add-cache-key-fn)*$ pytest
============================================================================================================================ test session starts =============================================================================================================================
platform darwin -- Python 3.11.9, pytest-7.1.3, pluggy-1.0.0
django: settings: tests.django.django_settings (from ini)
rootdir: /Users/jamie/Documents/code/gql-sync-dataloaders/graphql-sync-dataloaders, configfile: pyproject.toml, testpaths: tests/
plugins: django-4.5.2
collected 14 items

tests/django/test_graphene_django.py ..
tests/django/test_strawberry_django.py ..
tests/test_dataloader.py .......
tests/test_sync_future.py ...

============================================================================================================================= 14 passed in 0.08s =============================================================================================================================
```